### PR TITLE
🐛 티어메이커 리셋버튼 수정

### DIFF
--- a/src/_hooks/useTierMaker.ts
+++ b/src/_hooks/useTierMaker.ts
@@ -58,16 +58,26 @@ export default function useTierMaker() {
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchValue(value);
+    const result = playerList.filter(
+      (p) =>
+        !tierLines.some((line) => line.some((selected) => selected.id === p.id))
+    );
+
     if (value.trim() === "") {
-      setFilterPlayerList(playerList);
+      setFilterPlayerList(result);
     } else {
-      const filtered = playerList.filter((p) => p.name.includes(value));
+      const filtered = result.filter((p) => p.name.includes(value));
       setFilterPlayerList(filtered);
     }
   };
 
   const handleResetFilter = () => {
-    setFilterPlayerList(playerList);
+    //playerList 전체 플레이어중에 tierLines [][] 배열에 포함되어있지 않은 애들만
+    const result = playerList.filter(
+      (p) =>
+        !tierLines.some((line) => line.some((selected) => selected.id === p.id))
+    );
+    setFilterPlayerList(result);
     setSearchValue("");
     setSelectedPosition("포지션 선택");
   };

--- a/src/app/(route)/tiermaker/page.tsx
+++ b/src/app/(route)/tiermaker/page.tsx
@@ -65,7 +65,13 @@ export default function TierMaker() {
           <div className="flex items-center justify-between p-2 px-4 bg-[#333] font-bold text-white">
             <p>미분류 선수</p>
             <span className="rounded-[12px] px-2 bg-gray-600">
-              {filterPlayerList.length}
+              {
+                filterPlayerList.filter(
+                  (p) =>
+                    selectedPosition === "포지션 선택" ||
+                    p.position === selectedPosition
+                ).length
+              }
             </span>
           </div>
           <div


### PR DESCRIPTION
필터 리셋시 티어 측정된 플레이어는 제외
```
 const handleResetFilter = () => {
    //playerList 전체 플레이어중에 tierLines [][] 배열에 포함되어있지 않은 애들만
    const result = playerList.filter(
      (p) =>
        !tierLines.some((line) => line.some((selected) => selected.id === p.id))
    );
    setFilterPlayerList(result);
    setSearchValue("");
    setSelectedPosition("포지션 선택");
  };
```

